### PR TITLE
Disable source maps for less

### DIFF
--- a/src/Bundler/Processor/js/lessc.js
+++ b/src/Bundler/Processor/js/lessc.js
@@ -3,9 +3,6 @@ var path = require('path');
 
 function compile(source) {
     less.render(source, {
-        "sourceMap": {
-            "sourceMapFileInline": true
-        },
         "filename": path.resolve(process.argv[2])
     }, function (error, output) {
         if (null !== error) {


### PR DESCRIPTION
Compiling a test file with a source map took 11,5 seconds. Disabling it took that down to 1,35 seconds!